### PR TITLE
CORE-1177: throw server errors

### DIFF
--- a/src/common/helpers/start-server.js
+++ b/src/common/helpers/start-server.js
@@ -1,24 +1,15 @@
 import { config } from '../../config.js'
 
 import { createServer } from '../../server.js'
-import { createLogger } from './logging/logger.js'
 
 async function startServer() {
-  let server
+  const server = await createServer()
+  await server.start()
 
-  try {
-    server = await createServer()
-    await server.start()
-
-    server.logger.info('Server started successfully')
-    server.logger.info(
-      `Access your backend on http://localhost:${config.get('port')}`
-    )
-  } catch (error) {
-    const logger = createLogger()
-    logger.info('Server failed to start :(')
-    logger.error(error)
-  }
+  server.logger.info('Server started successfully')
+  server.logger.info(
+    `Access your backend on http://localhost:${config.get('port')}`
+  )
 
   return server
 }

--- a/src/common/helpers/start-server.test.js
+++ b/src/common/helpers/start-server.test.js
@@ -1,29 +1,5 @@
 import hapi from '@hapi/hapi'
 
-const mockLoggerInfo = vi.fn()
-const mockLoggerError = vi.fn()
-
-const mockHapiLoggerInfo = vi.fn()
-const mockHapiLoggerError = vi.fn()
-
-vi.mock('hapi-pino', () => ({
-  default: {
-    register: (server) => {
-      server.decorate('server', 'logger', {
-        info: mockHapiLoggerInfo,
-        error: mockHapiLoggerError
-      })
-    },
-    name: 'mock-hapi-pino'
-  }
-}))
-vi.mock('./logging/logger.js', () => ({
-  createLogger: () => ({
-    info: (...args) => mockLoggerInfo(...args),
-    error: (...args) => mockLoggerError(...args)
-  })
-}))
-
 describe('#startServer', () => {
   let createServerSpy
   let hapiServerSpy
@@ -49,30 +25,15 @@ describe('#startServer', () => {
 
       expect(createServerSpy).toHaveBeenCalled()
       expect(hapiServerSpy).toHaveBeenCalled()
-      expect(mockHapiLoggerInfo).toHaveBeenCalledWith('Setting up MongoDb')
-      expect(mockHapiLoggerInfo).toHaveBeenCalledWith(
-        'MongoDb connected to cdp-node-backend-template'
-      )
-      expect(mockHapiLoggerInfo).toHaveBeenCalledWith(
-        'Server started successfully'
-      )
-      expect(mockHapiLoggerInfo).toHaveBeenCalledWith(
-        'Access your backend on http://localhost:3098'
-      )
     })
   })
 
   describe('When server start fails', () => {
-    beforeAll(() => {
-      createServerSpy.mockRejectedValue(new Error('Server failed to start'))
-    })
-
     test('Should log failed startup message', async () => {
-      await startServerImport.startServer()
+      createServerSpy.mockRejectedValue(new Error('Server failed to start'))
 
-      expect(mockLoggerInfo).toHaveBeenCalledWith('Server failed to start :(')
-      expect(mockLoggerError).toHaveBeenCalledWith(
-        Error('Server failed to start')
+      await expect(startServerImport.startServer()).rejects.toThrow(
+        'Server failed to start'
       )
     })
   })


### PR DESCRIPTION
Simplify startServer work:
- Remove try catch
- Remove directional logging expects from test
- Test server throws as expected when erroring
